### PR TITLE
Display current block state without the block name in front (So it matches an input)

### DIFF
--- a/src/main/java/goldenshadow/displayentityeditor/items/GUIItems.java
+++ b/src/main/java/goldenshadow/displayentityeditor/items/GUIItems.java
@@ -420,9 +420,15 @@ public class GUIItems {
     public ItemStack blockState(String current) {
         ItemStack itemStack = new ItemStack(Material.CHEST_MINECART);
 
+        // Current is passed in as the block string, which looks like "minecraft:block[state1=true,state2=false]"
+        // To change the block state, you must only pass in the brackets, so "[state1=true,state2=false]"
+        // Therefore, we want to display only the state so that it reflects the input that would've been entered to achieve said block state.
+        // If the block has no state values, we can just return the brackets by themselves.
+        String currentState = current.contains("[") ? current.substring(current.indexOf('['), current.indexOf(']') + 1) : "[]";
+
         Utilities.setMeta(itemStack, ChatColor.YELLOW + "Set Block State",
                 List.of(
-                        ChatColor.GRAY + "Currently: " + ChatColor.DARK_AQUA + current,
+                        ChatColor.GRAY + "Currently: " + ChatColor.DARK_AQUA + currentState,
                         " ",
                         ChatColor.YELLOW + String.valueOf(ChatColor.BOLD) + "LEFT-CLICK " + ChatColor.RESET + ChatColor.YELLOW + "to enter new value",
                         ChatColor.YELLOW + String.valueOf(ChatColor.BOLD) + "RIGHT-CLICK " + ChatColor.RESET + ChatColor.YELLOW + "to reset"


### PR DESCRIPTION
Heya! Hope you're doing well!

Just wanted to stop by and add a QOL improvement to the plugin since honestly, it's overall a really cool tool for working with display entities!

Mostly -- I was a little confused with how the block states worked for a while until I realized that block state updates shouldn't have the block name at the front, just the state itself. So I switched it to display something that would work as an input like so:

![image](https://github.com/GoldenShad0w/DisplayEntityEditor/assets/38931647/7d227875-e270-416a-bdb3-d7104d0874d3)

For example, for a redstone lamp, the default value would go from `minecraft:redstone_lamp[lit=true]` to just `[lit=true]`.

![image](https://github.com/GoldenShad0w/DisplayEntityEditor/assets/38931647/f44cbee3-ed09-4d05-a5e7-58e345498403)

Should be blank for blocks that don't have a state.

Let me know if you have questions!