### PR TITLE
v1.0.15 - Critical bug fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>goldenshadow</groupId>
     <artifactId>DisplayEntityEditor</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
     <packaging>jar</packaging>
 
     <name>DisplayEntityEditor</name>

--- a/src/main/java/goldenshadow/displayentityeditor/EditingHandler.java
+++ b/src/main/java/goldenshadow/displayentityeditor/EditingHandler.java
@@ -3,6 +3,7 @@ package goldenshadow.displayentityeditor;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Player;
 
+import javax.annotation.Nullable;
 import java.util.*;
 
 public class EditingHandler {
@@ -35,11 +36,16 @@ public class EditingHandler {
      * as a singleton collection.
      * @see Utilities#getNearestDisplayEntity(org.bukkit.Location, boolean)
      */
+    @Nullable
     public Collection<Display> getEditingDisplays(Player player, boolean lockSearchToggle) {
         Collection<Display> displays = editingDisplaysMap.get(player.getUniqueId());
 
         if (displays == null) {
-            return Collections.singleton(Utilities.getNearestDisplayEntity(player.getLocation(), lockSearchToggle));
+            Display d = Utilities.getNearestDisplayEntity(player.getLocation(), lockSearchToggle);
+            if (d != null) {
+                return Collections.singleton(d);
+            }
+            return null;
         }
 
         return displays;

--- a/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
@@ -244,13 +244,14 @@ public class Interact implements Listener {
         if (toolValue.equals("InventoryUnlock")) {
             Collection<Display> displays = editingHandler.getEditingDisplays(player, false);
 
-            if (displays.isEmpty()) {
+            if (displays == null) {
                 player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("unlock_fail")));
                 return;
             }
 
             displays.forEach(display -> {
-                display.getPersistentDataContainer().remove(new NamespacedKey(DisplayEntityEditor.getPlugin(), "dee:locked"));
+                //Please do not replace these scoreboard tag locks with persistent data storage! This is an intentional design choice so that you can use vanilla commands to target locked displays
+                display.getScoreboardTags().remove("dee:locked");
                 highlightEntity(display);
             });
 
@@ -282,7 +283,7 @@ public class Interact implements Listener {
 
         Collection<Display> displays = editingHandler.getEditingDisplays(player, true);
 
-        if (displays.isEmpty()) {
+        if (displays == null) {
             player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("generic_fail")));
             return;
         }


### PR DESCRIPTION
v1.0.15 fixes two critical bugs. Once caused an error to occur when trying to unlock a display entity and the other caused an error when trying to use a tool with no unlocked display entity nearby