### PR TITLE
V1.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>goldenshadow</groupId>
     <artifactId>DisplayEntityEditor</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
     <packaging>jar</packaging>
 
     <name>DisplayEntityEditor</name>

--- a/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
+++ b/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
@@ -76,6 +76,7 @@ public final class DisplayEntityEditor extends JavaPlugin {
         Objects.requireNonNull(getCommand("displayentityeditor")).setExecutor(new Command());
         Objects.requireNonNull(getCommand("displayentityeditor")).setTabCompleter(new TabComplete());
         Bukkit.getPluginManager().registerEvents(new Interact(editingHandler), plugin);
+        Bukkit.getPluginManager().registerEvents(new OffhandSwap(editingHandler), plugin);
         Bukkit.getPluginManager().registerEvents(new InventoryClick(), plugin);
         Bukkit.getPluginManager().registerEvents(new InventoryClose(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerJoin(), plugin);
@@ -91,6 +92,16 @@ public final class DisplayEntityEditor extends JavaPlugin {
                 getLogger().warning(messageManager.getString("version_check_fail"));
             }
         });
+
+        if (getConfig().getBoolean("use-messages-file")) {
+            if (!getDescription().getVersion().equals(messageManager.getString("file_version"))) {
+                getLogger().warning(messageManager.getString("messages_file_outdated_version"));
+            }
+            if (!messageManager.isMessageMapComplete()) {
+                getLogger().warning(messageManager.getString("messages_file_incomplete"));
+            }
+        }
+
     }
 
     /**

--- a/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
+++ b/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
@@ -2,10 +2,7 @@ package goldenshadow.displayentityeditor;
 
 import goldenshadow.displayentityeditor.commands.Command;
 import goldenshadow.displayentityeditor.commands.TabComplete;
-import goldenshadow.displayentityeditor.events.Interact;
-import goldenshadow.displayentityeditor.events.InventoryClick;
-import goldenshadow.displayentityeditor.events.InventoryClose;
-import goldenshadow.displayentityeditor.events.PlayerJoin;
+import goldenshadow.displayentityeditor.events.*;
 import goldenshadow.displayentityeditor.inventories.InventoryFactory;
 import goldenshadow.displayentityeditor.items.GUIItems;
 import goldenshadow.displayentityeditor.items.InventoryItems;
@@ -82,6 +79,7 @@ public final class DisplayEntityEditor extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new InventoryClick(), plugin);
         Bukkit.getPluginManager().registerEvents(new InventoryClose(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerJoin(), plugin);
+        Bukkit.getPluginManager().registerEvents(new PlayerLeave(), plugin);
         toolPrecisionKey = new NamespacedKey(plugin, "toolPrecision");
 
         new Metrics(plugin, 18672);

--- a/src/main/java/goldenshadow/displayentityeditor/MessageManager.java
+++ b/src/main/java/goldenshadow/displayentityeditor/MessageManager.java
@@ -29,13 +29,13 @@ public class MessageManager {
 
     public String getString(String key) {
         String s = "";
-        if (messageMap.containsKey(key)) {
+        if (messageMap.containsKey(key) && DisplayEntityEditor.getPlugin().getConfig().getBoolean("use-messages-file")) {
             Object o = messageMap.get(key);
             if (o instanceof String) {
                 s = (String) o;
             }
         } else {
-            if (fallbackMap.containsKey(key)) {
+            if (fallbackMap.containsKey(key) && !key.equals("file_version")) { //file version should never be gotten from fallback
                 Object o = fallbackMap.get(key);
                 if (o instanceof String) {
                     s = (String) o;
@@ -47,7 +47,7 @@ public class MessageManager {
 
     public List<String> getList(String key) {
         Object o = null;
-        if (messageMap.containsKey(key)) {
+        if (messageMap.containsKey(key) && DisplayEntityEditor.getPlugin().getConfig().getBoolean("use-messages-file")) {
             o = messageMap.get(key);
         } else if (fallbackMap.containsKey(key)) {
             o = fallbackMap.get(key);
@@ -62,6 +62,17 @@ public class MessageManager {
             }
         }
         return returnList;
+    }
+
+    /**
+     * Used to check if all messages are in the messages.yml being used
+     * @return True if everything is fine, false if the file should be updated
+     */
+    public boolean isMessageMapComplete() {
+        for (String key : fallbackMap.keySet()) {
+            if (!messageMap.containsKey(key)) return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/goldenshadow/displayentityeditor/Utilities.java
+++ b/src/main/java/goldenshadow/displayentityeditor/Utilities.java
@@ -1,9 +1,9 @@
 package goldenshadow.displayentityeditor;
 
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.ComponentBuilder;
-import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.*;
+import net.md_5.bungee.api.chat.hover.content.Content;
+import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -171,10 +171,21 @@ public class Utilities {
 
     public static BaseComponent[] getCommandMessage(String commandMessage, String hint) {
         TextComponent click = new TextComponent(net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', DisplayEntityEditor.messageManager.getString("command_message").formatted(commandMessage, hint)));
-
         click.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/deeditor edit " + commandMessage));
 
         return new ComponentBuilder(click).create();
+    }
+
+    public static void sendActionbarMessage(Player p, String message) {
+        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(net.md_5.bungee.api.ChatColor.DARK_AQUA + message));
+    }
+
+    public static BaseComponent[] getClipboardMessage(String messageKey, String clipboardContent) {
+        TextComponent text = new TextComponent(net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', DisplayEntityEditor.messageManager.getString(messageKey)));
+
+        text.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(clipboardContent)));
+        text.setClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, clipboardContent));
+        return new ComponentBuilder(text).create();
     }
 
     public static String getObjectNameMessage(Object object) {
@@ -193,9 +204,9 @@ public class Utilities {
         else return "";
     }
 
-    public static double getToolPrecision(Player p) {
+    public static float getToolPrecision(Player p) {
         Double i = p.getPersistentDataContainer().get(DisplayEntityEditor.toolPrecisionKey,  PersistentDataType.DOUBLE);
-        return i != null ? i : 1;
+        return i != null ? i.floatValue() : 1;
     }
 
     public static String reduceFloatLength(String s) {

--- a/src/main/java/goldenshadow/displayentityeditor/commands/Command.java
+++ b/src/main/java/goldenshadow/displayentityeditor/commands/Command.java
@@ -41,7 +41,6 @@ public class Command implements CommandExecutor {
                 if (savedInventories.containsKey(p.getUniqueId())) {
                     returnInventory(p);
                     p.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("inventory_returned")));
-                    savedInventories.remove(p.getUniqueId());
                     return true;
                 }
                 saveInventory(p);
@@ -213,13 +212,14 @@ public class Command implements CommandExecutor {
      * A utility method used to return a players inventory
      * @param player The player whose inventory should be returned
      */
-    private static void returnInventory(Player player) {
-        if (!savedInventories.containsKey(player.getUniqueId())) throw new RuntimeException("Return inventory didn't exist!");
+    public static void returnInventory(Player player) {
+        if (!savedInventories.containsKey(player.getUniqueId())) return;
         player.getInventory().clear();
         ItemStack[] saved = savedInventories.get(player.getUniqueId());
         for (int i = 0; i < player.getInventory().getSize(); i++) {
             player.getInventory().setItem(i, saved[i]);
         }
+        savedInventories.remove(player.getUniqueId());
     }
 
     private static String collectArgsToString(String[] args) {

--- a/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
@@ -92,10 +92,6 @@ public class Interact implements Listener {
         display.getWorld().spawnParticle(Particle.VILLAGER_HAPPY, display.getLocation(), 50, 0.2, 0.2, 0.2, 0);
     }
 
-    private static void sendActionbarMessage(Player p, String message) {
-        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(net.md_5.bungee.api.ChatColor.DARK_AQUA + message));
-    }
-
     /**
      * Used to clone a display entity
      * @param clone The clone
@@ -223,62 +219,60 @@ public class Interact implements Listener {
             return;
         }
 
-        if (toolValue.equals("InventorySpawnItem")) {
-            spawnDisplayEntity(player.getLocation(), EntityType.ITEM_DISPLAY);
-            player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("item_display_spawned")));
-            return;
-        }
-
-        if (toolValue.equals("InventorySpawnBlock")) {
-            spawnDisplayEntity(player.getLocation(), EntityType.BLOCK_DISPLAY);
-            player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("block_display_spawned")));
-            return;
-        }
-
-        if (toolValue.equals("InventorySpawnText")) {
-            spawnDisplayEntity(player.getLocation(), EntityType.TEXT_DISPLAY);
-            player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("text_display_spawned")));
-            return;
-        }
-
-        if (toolValue.equals("InventoryUnlock")) {
-            Collection<Display> displays = editingHandler.getEditingDisplays(player, false);
-
-            if (displays == null) {
-                player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("unlock_fail")));
+        switch (toolValue) {
+            case "InventorySpawnItem" -> {
+                spawnDisplayEntity(player.getLocation(), EntityType.ITEM_DISPLAY);
+                player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("item_display_spawned")));
                 return;
             }
-
-            displays.forEach(display -> {
-                //Please do not replace these scoreboard tag locks with persistent data storage! This is an intentional design choice so that you can use vanilla commands to target locked displays
-                display.getScoreboardTags().remove("dee:locked");
-                highlightEntity(display);
-            });
-
-            player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("unlock_success")));
-            return;
-        }
-
-        if (toolValue.equals("InventoryToolPrecision")) {
-            double d = Utilities.getToolPrecision(player);
-            if (player.isSneaking()) {
-                if (d > 1) {
-                    d = Math.max(0.1, d - 1);
-                } else {
-                    d = Math.max(0.1, d - 0.1);
-                }
-            } else {
-                if (d < 1) {
-                    d = Math.min(10, d + 0.1);
-                } else {
-                    d = Math.min(10, d + 1);
-                }
+            case "InventorySpawnBlock" -> {
+                spawnDisplayEntity(player.getLocation(), EntityType.BLOCK_DISPLAY);
+                player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("block_display_spawned")));
+                return;
             }
-            d = (double) Math.round(d * 1000) / 1000;
-            player.getPersistentDataContainer().set(DisplayEntityEditor.toolPrecisionKey, PersistentDataType.DOUBLE, d);
-            updateItems(player);
-            sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("tool_precision").formatted(df.format(d)));
-            return;
+            case "InventorySpawnText" -> {
+                spawnDisplayEntity(player.getLocation(), EntityType.TEXT_DISPLAY);
+                player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("text_display_spawned")));
+                return;
+            }
+            case "InventoryUnlock" -> {
+                Collection<Display> displays = editingHandler.getEditingDisplays(player, false);
+
+                if (displays == null) {
+                    player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("unlock_fail")));
+                    return;
+                }
+
+                displays.forEach(display -> {
+                    //Please do not replace these scoreboard tag locks with persistent data storage! This is an intentional design choice so that you can use vanilla commands to target locked displays
+                    display.getScoreboardTags().remove("dee:locked");
+                    highlightEntity(display);
+                });
+
+                player.sendMessage(Utilities.getInfoMessageFormat(DisplayEntityEditor.messageManager.getString("unlock_success")));
+                return;
+            }
+            case "InventoryToolPrecision" -> {
+                double d = Utilities.getToolPrecision(player);
+                if (player.isSneaking()) {
+                    if (d > 1) {
+                        d = Math.max(0.1, d - 1);
+                    } else {
+                        d = Math.max(0.1, d - 0.1);
+                    }
+                } else {
+                    if (d < 1) {
+                        d = Math.min(10, d + 0.1);
+                    } else {
+                        d = Math.min(10, d + 1);
+                    }
+                }
+                d = (double) Math.round(d * 1000) / 1000;
+                player.getPersistentDataContainer().set(DisplayEntityEditor.toolPrecisionKey, PersistentDataType.DOUBLE, d);
+                updateItems(player);
+                Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("tool_precision").formatted(df.format(d)));
+                return;
+            }
         }
 
         Collection<Display> displays = editingHandler.getEditingDisplays(player, true);
@@ -316,7 +310,7 @@ public class Interact implements Listener {
                 if (player.isSneaking()) {
                     displays.forEach(display -> {
                         display.setRotation((float) (display.getLocation().getYaw() - 1 * Utilities.getToolPrecision(player)), display.getLocation().getPitch());
-                        sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("yaw").formatted(df.format(display.getLocation().getYaw())));
+                        Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("yaw").formatted(df.format(display.getLocation().getYaw())));
                     });
 
                     return;
@@ -324,21 +318,21 @@ public class Interact implements Listener {
 
                 displays.forEach(display -> {
                     display.setRotation((float) (display.getLocation().getYaw() + 1 * Utilities.getToolPrecision(player)), display.getLocation().getPitch());
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("yaw").formatted(df.format(display.getLocation().getYaw())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("yaw").formatted(df.format(display.getLocation().getYaw())));
                 });
             }
             case "InventoryRotatePitch" -> {
                 if (player.isSneaking()) {
                     displays.forEach(display -> {
                         display.setRotation(display.getLocation().getYaw(), (float) (display.getLocation().getPitch() - 1 * Utilities.getToolPrecision(player)));
-                        sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("pitch").formatted(df.format(display.getLocation().getPitch())));
+                        Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("pitch").formatted(df.format(display.getLocation().getPitch())));
                     });
                     return;
                 }
 
                 displays.forEach(display -> {
                     display.setRotation(display.getLocation().getYaw(), (float) (display.getLocation().getPitch() + 1 * Utilities.getToolPrecision(player)));
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("pitch").formatted(df.format(display.getLocation().getPitch())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("pitch").formatted(df.format(display.getLocation().getPitch())));
                 });
             }
             case "InventoryMoveX" -> {
@@ -346,8 +340,8 @@ public class Interact implements Listener {
                     displays.forEach(display -> {
                         display.teleport(display.getLocation().add(-0.1 * Utilities.getToolPrecision(player), 0, 0));
 
-                        sendActionbarMessage(player, "X: " + df.format(display.getLocation().getX()));
-                        sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_x").formatted(df.format(display.getLocation().getX())));
+                        Utilities.sendActionbarMessage(player, "X: " + df.format(display.getLocation().getX()));
+                        Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_x").formatted(df.format(display.getLocation().getX())));
                     });
 
                     return;
@@ -355,7 +349,7 @@ public class Interact implements Listener {
 
                 displays.forEach(display -> {
                     display.teleport(display.getLocation().add(0.1 * Utilities.getToolPrecision(player), 0, 0));
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_x").formatted(df.format(display.getLocation().getX())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_x").formatted(df.format(display.getLocation().getX())));
                 });
 
 
@@ -364,14 +358,14 @@ public class Interact implements Listener {
                 if (player.isSneaking()) {
                     displays.forEach(display -> {
                         display.teleport(display.getLocation().add(0, -0.1 * Utilities.getToolPrecision(player), 0));
-                        sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_y").formatted(df.format(display.getLocation().getY())));
+                        Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_y").formatted(df.format(display.getLocation().getY())));
                     });
 
                     return;
                 }
                 displays.forEach(display -> {
                     display.teleport(display.getLocation().add(0, 0.1 * Utilities.getToolPrecision(player), 0));
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_y").formatted(df.format(display.getLocation().getY())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_y").formatted(df.format(display.getLocation().getY())));
                 });
 
             }
@@ -379,14 +373,14 @@ public class Interact implements Listener {
                 if (player.isSneaking()) {
                     displays.forEach(display -> {
                         display.teleport(display.getLocation().add(0, 0, -0.1 * Utilities.getToolPrecision(player)));
-                        sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_z").formatted(df.format(display.getLocation().getZ())));
+                        Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_z").formatted(df.format(display.getLocation().getZ())));
                     });
 
                     return;
                 }
                 displays.forEach(display -> {
                     display.teleport(display.getLocation().add(0, 0, 0.1 * Utilities.getToolPrecision(player)));
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_z").formatted(df.format(display.getLocation().getZ())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("move_z").formatted(df.format(display.getLocation().getZ())));
                 });
 
             }
@@ -403,7 +397,7 @@ public class Interact implements Listener {
                     }
                     display.setTransformation(t);
                 });
-                sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("center_pivot"));
+                Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("center_pivot"));
             }
             case "InventoryTX" -> {
                 displays.forEach(display -> {
@@ -413,7 +407,7 @@ public class Interact implements Listener {
                     } else {
                         t.getTranslation().add((float) (0.1f * Utilities.getToolPrecision(player)), 0, 0);
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("translation_x").formatted(df.format(t.getTranslation().x())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("translation_x").formatted(df.format(t.getTranslation().x())));
                     display.setTransformation(t);
                 });
             }
@@ -425,7 +419,7 @@ public class Interact implements Listener {
                     } else {
                         t.getTranslation().add(0, (float) (0.1f * Utilities.getToolPrecision(player)), 0);
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("translation_y").formatted(df.format(t.getTranslation().y())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("translation_y").formatted(df.format(t.getTranslation().y())));
                     display.setTransformation(t);
                 });
             }
@@ -437,7 +431,7 @@ public class Interact implements Listener {
                     } else {
                         t.getTranslation().add(0, 0, (float) (0.1f * Utilities.getToolPrecision(player)));
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("translation_z").formatted(df.format(t.getTranslation().z())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("translation_z").formatted(df.format(t.getTranslation().z())));
                     display.setTransformation(t);
                 });
             }
@@ -449,7 +443,7 @@ public class Interact implements Listener {
                     } else {
                         t.getScale().add((float) (0.1f * Utilities.getToolPrecision(player)), 0, 0);
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("scale_x").formatted(df.format(t.getScale().x())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("scale_x").formatted(df.format(t.getScale().x())));
                     display.setTransformation(t);
                 });
             }
@@ -461,7 +455,7 @@ public class Interact implements Listener {
                     } else {
                         t.getScale().add(0, (float) (0.1f * Utilities.getToolPrecision(player)), 0);
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("scale_y").formatted(df.format(t.getScale().y())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("scale_y").formatted(df.format(t.getScale().y())));
                     display.setTransformation(t);
                 });
             }
@@ -473,7 +467,7 @@ public class Interact implements Listener {
                     } else {
                         t.getScale().add(0, 0, (float) (0.1f * Utilities.getToolPrecision(player)));
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("scale_z").formatted(df.format(t.getScale().z())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("scale_z").formatted(df.format(t.getScale().z())));
                     display.setTransformation(t);
                 });
             }
@@ -489,7 +483,7 @@ public class Interact implements Listener {
                     if (b) {
                         t.getLeftRotation().normalize();
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("left_rot_x").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getLeftRotation().x())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("left_rot_x").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getLeftRotation().x())));
                     display.setTransformation(t);
                 });
             }
@@ -505,7 +499,7 @@ public class Interact implements Listener {
                     if (b) {
                         t.getLeftRotation().normalize();
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("left_rot_y").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getLeftRotation().y())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("left_rot_y").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getLeftRotation().y())));
                     display.setTransformation(t);
                 });
             }
@@ -521,7 +515,7 @@ public class Interact implements Listener {
                     if (b) {
                         t.getLeftRotation().normalize();
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("left_rot_z").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getLeftRotation().z())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("left_rot_z").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getLeftRotation().z())));
                     display.setTransformation(t);
                 });
             }
@@ -537,7 +531,7 @@ public class Interact implements Listener {
                     if (b) {
                         t.getRightRotation().normalize();
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("right_rot_x").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getRightRotation().x())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("right_rot_x").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getRightRotation().x())));
                     display.setTransformation(t);
                 });
             }
@@ -553,7 +547,7 @@ public class Interact implements Listener {
                     if (b) {
                         t.getRightRotation().normalize();
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("right_rot_y").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getRightRotation().y())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("right_rot_y").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getRightRotation().y())));
                     display.setTransformation(t);
                 });
             }
@@ -569,7 +563,7 @@ public class Interact implements Listener {
                     if (b) {
                         t.getRightRotation().normalize();
                     }
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("right_rot_z").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getRightRotation().z())));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("right_rot_z").formatted((b ? DisplayEntityEditor.messageManager.getString("normalized") : ""), df.format(t.getRightRotation().z())));
                     display.setTransformation(t);
                 });
             }
@@ -588,7 +582,7 @@ public class Interact implements Listener {
                         loc.setY((int) loc.getY() + (((loc.getY()) < 0 ? -1 : 1) * 0.5));
                     }
                     display.teleport(loc);
-                    sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("center_block").formatted(loc.getX(), loc.getY(), loc.getZ()));
+                    Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("center_block").formatted(loc.getX(), loc.getY(), loc.getZ()));
                 });
 
             }
@@ -597,7 +591,7 @@ public class Interact implements Listener {
                     Display clone = (Display) display.getWorld().spawnEntity(display.getLocation(), display.getType(), false);
                     cloneEntity(clone, display);
                 });
-                sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("clone"));
+                Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("clone"));
             }
             case "InventoryGroupSelect" -> {
                 if (!player.isSneaking()) {

--- a/src/main/java/goldenshadow/displayentityeditor/events/InventoryClick.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/InventoryClick.java
@@ -380,18 +380,23 @@ public class InventoryClick implements Listener {
                             case "GUIText" -> {
                                 if (event.isLeftClick()) {
                                     player.closeInventory();
+                                    TextDisplay textDisplay = (TextDisplay) entity;
 
                                     if (DisplayEntityEditor.alternateTextInput) {
                                         if (DisplayEntityEditor.useMiniMessageFormat) {
                                             player.spigot().sendMessage(Utilities.getCommandMessage("text <new_text>", DisplayEntityEditor.messageManager.getString("text_command_hint_mm")));
+                                            player.spigot().sendMessage(Utilities.getClipboardMessage("text_clipboard_hint", textDisplay.getText()));
                                         } else {
                                             player.spigot().sendMessage(Utilities.getCommandMessage("text <new_text>", DisplayEntityEditor.messageManager.getString("text_command_hint")));
+                                            player.spigot().sendMessage(Utilities.getClipboardMessage("text_clipboard_hint", textDisplay.getText()));
                                         }
                                     } else {
                                         if (DisplayEntityEditor.useMiniMessageFormat) {
                                             InputManager.createTextInput(player, DisplayEntityEditor.messageManager.getString("text_hint_mm"), new InputData(entity, InputType.TEXT, null));
+                                            player.spigot().sendMessage(Utilities.getClipboardMessage("text_clipboard_hint", textDisplay.getText()));
                                         } else {
                                             InputManager.createTextInput(player, DisplayEntityEditor.messageManager.getString("text_hint"), new InputData(entity, InputType.TEXT, null));
+                                            player.spigot().sendMessage(Utilities.getClipboardMessage("text_clipboard_hint", textDisplay.getText()));
                                         }
                                     }
                                 }
@@ -417,7 +422,7 @@ public class InventoryClick implements Listener {
                     }
                 }
             }
-            if (player.getOpenInventory().getTitle().equals(ChatColor.BOLD + "Block Display GUI")) {
+            if (player.getOpenInventory().getTitle().equals(ChatColor.translateAlternateColorCodes('&' ,DisplayEntityEditor.messageManager.getString("block_display_gui_name")))) {
 
                 assert entity instanceof BlockDisplay;
                 BlockDisplay blockDisplay = (BlockDisplay) entity;
@@ -439,7 +444,7 @@ public class InventoryClick implements Listener {
                 });
 
 
-            } else if (player.getOpenInventory().getTitle().equals(ChatColor.BOLD + "Item Display GUI")) {
+            } else if (player.getOpenInventory().getTitle().equals(ChatColor.translateAlternateColorCodes('&' ,DisplayEntityEditor.messageManager.getString("item_display_gui_name")))) {
                 ItemDisplay itemDisplay = (ItemDisplay) entity;
                 Bukkit.getScheduler().scheduleSyncDelayedTask(DisplayEntityEditor.getPlugin(), () -> itemDisplay.setItemStack(player.getOpenInventory().getItem(10)),1L);
             }

--- a/src/main/java/goldenshadow/displayentityeditor/events/OffhandSwap.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/OffhandSwap.java
@@ -1,0 +1,139 @@
+package goldenshadow.displayentityeditor.events;
+
+import goldenshadow.displayentityeditor.DisplayEntityEditor;
+import goldenshadow.displayentityeditor.EditingHandler;
+import goldenshadow.displayentityeditor.Utilities;
+import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Transformation;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import java.util.Collection;
+
+public class OffhandSwap implements Listener {
+
+    private final EditingHandler editingHandler;
+
+    public OffhandSwap(EditingHandler handler) {
+        editingHandler = handler;
+    }
+
+    @EventHandler
+    public void offHand(PlayerSwapHandItemsEvent event) {
+        Player player = event.getPlayer();
+        if (!Utilities.hasDataKey(player.getInventory().getItemInMainHand())) {
+            return;
+        }
+        event.setCancelled(true);
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        String toolValue = Utilities.getToolValue(item);
+        Collection<Display> displays = editingHandler.getEditingDisplays(player, true);
+
+        if (displays == null) {
+            player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("generic_fail")));
+            return;
+        }
+
+        if (toolValue == null) {
+            return;
+        }
+        Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("value_reset"));
+        switch (toolValue) {
+            case "InventoryRotateYaw" -> {
+                displays.forEach(display -> display.setRotation(0, display.getLocation().getPitch()));
+            }
+            case "InventoryRotatePitch" -> {
+                displays.forEach(display -> display.setRotation(display.getLocation().getYaw(), 0));
+            }
+            case "InventoryTX" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(new Vector3f(0, t.getTranslation().y(), t.getTranslation().z()), t.getLeftRotation(), t.getScale(), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryTY" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(new Vector3f(t.getTranslation().x(), 0, t.getTranslation().z()), t.getLeftRotation(), t.getScale(), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryTZ" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(new Vector3f(t.getTranslation().x(), t.getTranslation().y(), 0), t.getLeftRotation(), t.getScale(), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventorySX" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), t.getLeftRotation(), new Vector3f(0, t.getScale().y(), t.getScale().z()), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventorySY" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), t.getLeftRotation(), new Vector3f(t.getScale().x(), 0, t.getScale().z()), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventorySZ" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), t.getLeftRotation(), new Vector3f(t.getScale().x(), t.getScale().y(), 0), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryLRX" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), new Quaternionf(0, t.getLeftRotation().y(), t.getLeftRotation().z(), t.getLeftRotation().w()), t.getScale(), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryLRY" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), new Quaternionf(t.getLeftRotation().x(), 0, t.getLeftRotation().z(), t.getLeftRotation().w()), t.getScale(), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryLRZ" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), new Quaternionf(t.getLeftRotation().x(), t.getLeftRotation().y(), 0, t.getLeftRotation().w()), t.getScale(), t.getRightRotation());
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryRRX" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), t.getLeftRotation(), t.getScale(), new Quaternionf(0, t.getRightRotation().y(), t.getRightRotation().z(), t.getRightRotation().w()));
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryRRY" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), t.getLeftRotation(), t.getScale(), new Quaternionf(t.getRightRotation().x(), 0, t.getRightRotation().z(), t.getRightRotation().w()));
+                    display.setTransformation(t);
+                });
+            }
+            case "InventoryRRZ" -> {
+                displays.forEach(display -> {
+                    Transformation t = display.getTransformation();
+                    t = new Transformation(t.getTranslation(), t.getLeftRotation(), t.getScale(), new Quaternionf(t.getRightRotation().x(), t.getRightRotation().y(), 0, t.getRightRotation().w()));
+                    display.setTransformation(t);
+                });
+            }
+        }
+    }
+}

--- a/src/main/java/goldenshadow/displayentityeditor/events/PlayerJoin.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/PlayerJoin.java
@@ -2,6 +2,7 @@ package goldenshadow.displayentityeditor.events;
 
 import goldenshadow.displayentityeditor.DisplayEntityEditor;
 import goldenshadow.displayentityeditor.Utilities;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -24,6 +25,17 @@ public class PlayerJoin implements Listener {
                         event.getPlayer().sendMessage(ChatColor.GRAY + DisplayEntityEditor.messageManager.getString("version_check_disable_hint"));
                     }
                 });
+
+                Bukkit.getScheduler().scheduleSyncDelayedTask(DisplayEntityEditor.getPlugin(), () -> {
+                    if (DisplayEntityEditor.getPlugin().getConfig().getBoolean("use-messages-file")) {
+                        if (!DisplayEntityEditor.getPlugin().getDescription().getVersion().equals(DisplayEntityEditor.messageManager.getString("file_version"))) {
+                            event.getPlayer().sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("messages_file_outdated_version")));
+                        }
+                        if (!DisplayEntityEditor.messageManager.isMessageMapComplete()) {
+                            event.getPlayer().sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("messages_file_incomplete")));
+                        }
+                    }
+                }, 10L);
             }
         }
     }

--- a/src/main/java/goldenshadow/displayentityeditor/events/PlayerLeave.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/PlayerLeave.java
@@ -1,0 +1,18 @@
+package goldenshadow.displayentityeditor.events;
+
+import goldenshadow.displayentityeditor.commands.Command;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PlayerLeave implements Listener {
+
+    /**
+     * Used to listen for when a player leaves
+     * @param event The event
+     */
+    @EventHandler
+    public void onLeave(PlayerQuitEvent event) {
+        Command.returnInventory(event.getPlayer());
+    }
+}

--- a/src/main/java/goldenshadow/displayentityeditor/items/GUIItems.java
+++ b/src/main/java/goldenshadow/displayentityeditor/items/GUIItems.java
@@ -360,7 +360,7 @@ public class GUIItems {
         ItemStack itemStack = new ItemStack(Material.RED_BANNER);
 
         Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("text_background_color_name"),
-                DisplayEntityEditor.messageManager.getList("text_background_color_name"),
+                DisplayEntityEditor.messageManager.getList("text_background_color_lore"),
                 "GUITextBackgroundColor",
                 Utilities.getColor(current)
         );

--- a/src/main/java/goldenshadow/displayentityeditor/items/GUIItems.java
+++ b/src/main/java/goldenshadow/displayentityeditor/items/GUIItems.java
@@ -378,7 +378,7 @@ public class GUIItems {
         Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("text_background_opacity_name"),
                 DisplayEntityEditor.messageManager.getList("text_background_opacity_lore"),
                 "GUITextBackgroundOpacity",
-                Utilities.getColor(current)
+                current.getAlpha()
         );
         return itemStack;
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,4 @@
 send-update-message-on-join: true
 alternate-text-input: false
 use-minimessage-format: false
+use-messages-file: false

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -7,6 +7,8 @@
 #
 #  IMPORTANT: Do not delete '%s', '%d' or '%f'! Those are placeholders for variables!
 #
+# File version; Do not change this unless you know what you are doing!
+file_version: "${project.version}"
 # General Messages
 version_check_success: "You are on the latest version!"
 version_check_fail: "You are not running the latest version! Update your plugin here: https://www.spigotmc.org/resources/display-entity-editor.110267/"
@@ -15,6 +17,8 @@ version_check_disable_hint: "If you would like to disable these messages, you ca
 info_message_format: "&3[DEE] &b%s"
 error_message_format: "&4[DEE] &c%s"
 command_message: "&3[DEE] &bRun command &7\"/deeditor %s\"&b to edit the entity or click this message. %s"
+messages_file_outdated_version: "Your messages.yml file is using an outdated version! Consider deleting it and generating a new one."
+messages_file_incomplete: "Your messages.yml file is incomplete! Consider deleting it and generating a new one."
 
 
 # Inventory Items
@@ -22,7 +26,7 @@ open_gui_name: "&eOpen GUI"
 open_gui_lore: ["&7Click to open the GUI of the", "&7nearest unlocked display entity", " ", "&e&lRIGHT-CLICK&r&e to open"]
 rotate_yaw_name: "&eRotate Horizontally (yaw)"
 rotate_pitch_name: "&eRotate Vertically (pitch)"
-rotate_lore: ["&7Click to rotate the nearest", "&7unlocked display entity", " ", "&e&lRIGHT-CLICK&r&e to rotate by +%s", "&e&lSHIFT RIGHT-CLICK &r&eto rotate by -%s"]
+rotate_lore: ["&7Click to rotate the nearest", "&7unlocked display entity", " ", "&e&lRIGHT-CLICK&r&e to rotate by +%s", "&e&lSHIFT RIGHT-CLICK &r&eto rotate by -%s", "&e&lOFFHAND &r&eto reset value"]
 move_x_name: "&eMove X (Teleport)"
 move_y_name: "&eMove Y (Teleport)"
 move_z_name: "&eMove Z (Teleport)"
@@ -40,21 +44,21 @@ highlight_target_lore: ["&7Click to highlight the display entity", "&7that will 
 left_rotation_x_name: "&eLeft Rotation X"
 left_rotation_y_name: "&eLeft Rotation Y"
 left_rotation_z_name: "&eLeft Rotation Z"
-left_rotation_lore: ["&7Click to change the left rotation", "&7of the nearest unlocked display entity", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s"]
+left_rotation_lore: ["&7Click to change the left rotation", "&7of the nearest unlocked display entity", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s", "&e&lOFFHAND &r&eto reset value"]
 right_rotation_x_name: "&eRight Rotation X"
 right_rotation_y_name: "&eRight Rotation Y"
 right_rotation_z_name: "&eRight Rotation Z"
-right_rotation_lore: ["&7Click to change the right rotation", "&7of the nearest unlocked display entity", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s"]
+right_rotation_lore: ["&7Click to change the right rotation", "&7of the nearest unlocked display entity", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s", "&e&lOFFHAND &r&eto reset value"]
 center_pivot_name: "&eCenter Pivot Point"
 center_pivot_lore: ["&7Click to auto adjust the translation so that", "&7the pivot is centered relative to the scale.", "&7This will make it easier to rotate the entity", "&7around itself", " ", "&e&lRIGHT-CLICK&r&e to center"]
 translation_x_name: "&eTranslation X"
 translation_y_name: "&eTranslation Y"
 translation_z_name: "&eTranslation Z"
-translation_lore: ["&7Click to change the translation of", "&7the nearest unlocked display entity.", "&7Changing the translation will move the", "&7visual part of the entity but not its", "&7hitbox or pivot point", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s"]
+translation_lore: ["&7Click to change the translation of", "&7the nearest unlocked display entity.", "&7Changing the translation will move the", "&7visual part of the entity but not its", "&7hitbox or pivot point", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s", "&e&lOFFHAND &r&eto reset value"]
 scale_x_name: "&eScale X"
 scale_y_name: "&eScale Y"
 scale_z_name: "&eScale Z"
-scale_lore: ["&7Click to change the scale of the", "&7nearest unlocked display entity.", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s"]
+scale_lore: ["&7Click to change the scale of the", "&7nearest unlocked display entity.", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s", "&e&lOFFHAND &r&eto reset value"]
 center_on_block_name: "&eCenter On Block"
 center_on_block_lore: ["&7Click to position the nearest display entity", "&7so that it is centered on the block.", " ", "&e&lRIGHT-CLICK&r&e to center xyz", "&e&lSHIFT RIGHT-CLICK&r&e to center xz"]
 tool_precision_name: "&eChange Tool Precision"
@@ -108,7 +112,7 @@ text_shadow_lore: ["&7Currently: &3%s", "&7Defines whether the text should", "&7
 text_background_color_name: "&eSet Background Color"
 text_background_color_lore: ["&7Currently: &3%s", " ", "&e&lLEFT-CLICK&r&e to set from RGB value"]
 text_background_opacity_name: "&eSet Background Opacity"
-text_background_opacity_lore: ["&7Currently: &3%s", "&7Used to change the opacity of the background color.", "&eShould be able value between 0 and 255 (inclusive)", " ", "&e&lLEFT-CLICK&r&e to enter new value"]
+text_background_opacity_lore: ["&7Currently: &3%d", "&7Used to change the opacity of the background color.", "&7Should be able value between 0 and 255 (inclusive)", " ", "&e&lLEFT-CLICK&r&e to enter new value"]
 text_alignment_name: "&eSet Text Alignment"
 text_alignment_lore: ["&7Currently: &3%s", " ", "&e&lLEFT-CLICK&r&e to change"]
 text_name: "&eSet Text"
@@ -136,6 +140,7 @@ text_command_hint_mm: "Use MiniMessage formatting to stylize your input."
 text_command_hint: "You can use '&' for color codes and \\n to create line breaks."
 text_hint_mm: "Please enter the new text in chat! Use MiniMessage formatting to stylize your input."
 text_hint: "Please enter the new text in chat! You can use '&' for color codes and \\n to create line breaks."
+text_clipboard_hint: "&7&nClick here to copy the previous text to your clipboard!"
 text_append_hint_mm: "Please enter the text in chat the should be appended! Use MiniMessage formatting to stylize your input."
 text_append_hint: "Please enter the text in chat that should be appended! You can use '&' for color codes and \\n to create line breaks."
 block_invalid_hint: "Invalid block! The item must be a block item!"
@@ -174,6 +179,7 @@ clone: "Display entity cloned!"
 group_select_fail: "There are no unlocked display entities within the specified range!"
 group_select_success: "Created group containing %s display entities!"
 group_select_clear: "Cleared current editing group!"
+value_reset: "Value reset!"
 
 # Input prompts
 prompt_escape_word: "cancel"


### PR DESCRIPTION
v1.0.16 fixes some bugs and adds some new features:

- When setting the text of a TextDisplay, you will now have to option of copying the old text to your clipboard
- A bunch of tools can now reset the value they control via the offhand key. These tools are: yaw, pitch, translation (x,y,z), scale (x,y,z), left rotation (x,y,z) and right rotation (x,y,z)
- Admins will now be warned if they are using the messages.yml file and it is no longer up to date or missing entries
- The use of the messages.yml file is now off by default and can be enabled in the config. This is to prevent item descriptions from becoming out of date due to neglect from a server admin

**If you are using the messages.yml file, you will need to set "use-messages-file" to true in the config.yml now!!!**