### PR TITLE
Add Raycast selection mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 *.ipr
 *.iws
 
+# Eclipse
+.settings/
+.classpath
+.project
+
 # IntelliJ
 out/
 

--- a/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
+++ b/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
@@ -14,6 +14,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.conversations.ConversationFactory;
 import org.bukkit.entity.Display;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.*;
@@ -114,6 +115,13 @@ public final class DisplayEntityEditor extends JavaPlugin {
             }
         }
 
+    }
+    
+    @Override
+    public void onDisable() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            Command.returnInventory(player);
+        }
     }
 
     /**

--- a/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
+++ b/src/main/java/goldenshadow/displayentityeditor/DisplayEntityEditor.java
@@ -29,7 +29,6 @@ public final class DisplayEntityEditor extends JavaPlugin {
     public static ConversationFactory conversationFactory;
     public static InventoryFactory inventoryFactory;
     public static HashMap<UUID, Display> currentEditMap = new HashMap<>();
-    public static NamespacedKey toolPrecisionKey;
     public static boolean alternateTextInput = false;
     public static boolean useMiniMessageFormat = false;
     public static MiniMessage miniMessage = MiniMessage.builder()
@@ -48,6 +47,13 @@ public final class DisplayEntityEditor extends JavaPlugin {
             )
             .build();
     public static MessageManager messageManager;
+
+    public static NamespacedKey toolSelectionModeKey;
+    public static NamespacedKey toolSelectionRangeKey;
+    public static NamespacedKey toolSelectionMultipleKey;
+    public static NamespacedKey toolSelectionSearchModeKey;
+    public static NamespacedKey toolPrecisionKey;
+    public static NamespacedKey toolKey;
 
     private EditingHandler editingHandler;
 
@@ -81,7 +87,13 @@ public final class DisplayEntityEditor extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new InventoryClose(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerJoin(), plugin);
         Bukkit.getPluginManager().registerEvents(new PlayerLeave(), plugin);
+        
+        toolSelectionModeKey = new NamespacedKey(plugin, "toolSelectionMode");
+        toolSelectionRangeKey = new NamespacedKey(plugin, "toolSelectionRange");
+        toolSelectionMultipleKey = new NamespacedKey(plugin, "toolSelectionMultiple");
+        toolSelectionSearchModeKey = new NamespacedKey(plugin, "toolSelectionSearchMode");
         toolPrecisionKey = new NamespacedKey(plugin, "toolPrecision");
+        toolKey = new NamespacedKey(plugin, "tool");
 
         new Metrics(plugin, 18672);
 

--- a/src/main/java/goldenshadow/displayentityeditor/EditingHandler.java
+++ b/src/main/java/goldenshadow/displayentityeditor/EditingHandler.java
@@ -3,6 +3,8 @@ package goldenshadow.displayentityeditor;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Player;
 
+import goldenshadow.displayentityeditor.enums.LockSearchMode;
+
 import javax.annotation.Nullable;
 import java.util.*;
 
@@ -30,25 +32,30 @@ public class EditingHandler {
 
     /**
      * @param player The player that is editing display(s).
-     * @param lockSearchToggle Whether the searched entities should be locked/unlocked.
      * @return The collection of displays the player is currently editing.
-     * If the player is not editing any displays, the nearest display entity to the player's location is returned
-     * as a singleton collection.
-     * @see Utilities#getNearestDisplayEntity(org.bukkit.Location, boolean)
+     * If the player is not editing any displays, an display search is being started according to the players' @{link SelectionMode}.
+     *
+     * Please note that this method will use the players' currently selected {@link LockSearchMode}.
      */
     @Nullable
-    public Collection<Display> getEditingDisplays(Player player, boolean lockSearchToggle) {
+    public Collection<Display> getEditingDisplays(Player player) {
+        return getEditingDisplays(player, Utilities.getToolSearchMode(player));
+    }
+    
+    /**
+     * @param player The player that is editing display(s).
+     * @param lockSearchMode The lock search mode to check if an entity should be included in the selection or not.
+     * @return The collection of displays the player is currently editing.
+     * If the player is not editing any displays, an display search is being started according to the players' @{link SelectionMode}.
+     * @see SelectionMode#select(Player, LockSearchMode)
+     */
+    @Nullable
+    public Collection<Display> getEditingDisplays(Player player, LockSearchMode lockSearchMode) {
         Collection<Display> displays = editingDisplaysMap.get(player.getUniqueId());
-
-        if (displays == null) {
-            Display d = Utilities.getNearestDisplayEntity(player.getLocation(), lockSearchToggle);
-            if (d != null) {
-                return Collections.singleton(d);
-            }
-            return null;
+        if (displays != null) {
+            return displays;
         }
-
-        return displays;
+        return Utilities.getToolSelectMode(player).select(player, lockSearchMode);
     }
 
 }

--- a/src/main/java/goldenshadow/displayentityeditor/SelectionMode.java
+++ b/src/main/java/goldenshadow/displayentityeditor/SelectionMode.java
@@ -58,7 +58,7 @@ public abstract class SelectionMode {
             List<Display> displays;
             for (double distance = 0d; distance < range; distance += 0.25d) {
                 displays = world.getNearbyEntities(loc = new Location(world, x + dx * distance, y + dy * distance, z + dz * distance),
-                    0.5d, 0.25d, 0.5d).stream().filter(DISPLAY_FILTER).map(DISPLAY_CAST).filter(lockFilter).toList();
+                    0.75d, 0.25d, 0.75d).stream().filter(DISPLAY_FILTER).map(DISPLAY_CAST).filter(lockFilter).toList();
                 if (displays.isEmpty()) {
                     continue;
                 }

--- a/src/main/java/goldenshadow/displayentityeditor/SelectionMode.java
+++ b/src/main/java/goldenshadow/displayentityeditor/SelectionMode.java
@@ -58,7 +58,7 @@ public abstract class SelectionMode {
             List<Display> displays;
             for (double distance = 0d; distance < range; distance += 0.25d) {
                 displays = world.getNearbyEntities(loc = new Location(world, x + dx * distance, y + dy * distance, z + dz * distance),
-                    0.8d, 0.25d, 0.8d).stream().filter(DISPLAY_FILTER).map(DISPLAY_CAST).filter(lockFilter).toList();
+                    0.5d, 0.25d, 0.5d).stream().filter(DISPLAY_FILTER).map(DISPLAY_CAST).filter(lockFilter).toList();
                 if (displays.isEmpty()) {
                     continue;
                 }

--- a/src/main/java/goldenshadow/displayentityeditor/SelectionMode.java
+++ b/src/main/java/goldenshadow/displayentityeditor/SelectionMode.java
@@ -1,0 +1,109 @@
+package goldenshadow.displayentityeditor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.RayTraceResult;
+
+import goldenshadow.displayentityeditor.enums.LockSearchMode;
+
+public abstract class SelectionMode {
+
+    private static final Predicate<Entity> DISPLAY_FILTER = entity -> entity instanceof Display;
+    private static final Function<Entity, Display> DISPLAY_CAST = entity -> (Display) entity;
+
+    private static final HashMap<String, SelectionMode> idToMode = new HashMap<>();
+    private static final ArrayList<String> idOrder = new ArrayList<>();
+    
+    public static int amount() {
+        return idOrder.size();
+    }
+
+    public static SelectionMode get(String mode) {
+        return idToMode.get(mode);
+    }
+
+    public static final SelectionMode NEARBY = new SelectionMode("nearby") {
+
+        @Override
+        protected Stream<Display> select(Player p, double range) {
+            return p.getWorld().getNearbyEntities(p.getLocation(), range, range, range).stream().filter(DISPLAY_FILTER).map(DISPLAY_CAST);
+        }
+
+    };
+
+    public static final SelectionMode RAYCAST = new SelectionMode("raycast") {
+
+        @Override
+        protected Stream<Display> select(Player p, double range) {
+            RayTraceResult result = p.getWorld().rayTraceEntities(p.getEyeLocation(), p.getEyeLocation().getDirection(), range, 0.1d);
+            if (result.getHitEntity() == null || !(result.getHitEntity() instanceof Display display)) {
+                return Stream.empty();
+            }
+            return Stream.of(display);
+        }
+
+    };
+
+    private final String id;
+
+    public SelectionMode(String id) {
+        this.id = id;
+        idOrder.add(id);
+        idToMode.put(id, this);
+    }
+
+    public final String id() {
+        return id;
+    }
+    
+    public final int index() {
+        return idOrder.indexOf(id);
+    }
+    
+    public final SelectionMode previousMode() {
+        int i = idOrder.indexOf(id);
+        return idToMode.get(i == 0 ? idOrder.get(idOrder.size() - 1) : idOrder.get(i - 1));
+    }
+    
+    public final SelectionMode nextMode() {
+        int i = idOrder.indexOf(id);
+        return idToMode.get(i + 1 == idOrder.size() ? idOrder.get(0) : idOrder.get(i + 1));
+    }
+
+    public final List<Display> select(Player p, LockSearchMode lockSearchMode) {
+        List<Display> displays = select(p, Utilities.getToolSelectRange(p)).filter(lockSearchMode.getPredicate()).toList();
+        if (displays.isEmpty()) {
+            return null;
+        }
+        if (displays.size() == 1) {
+            return displays;
+        }
+        if (Utilities.getToolSelectMultiple(p)) {
+            return displays;
+        }
+        Display closest = null;
+        double tmp, distance = Double.MAX_VALUE;
+        Location pLoc = p.getLocation();
+        for (Display display : displays) {
+            tmp = pLoc.distanceSquared(display.getLocation());
+            if (tmp < distance) {
+                distance = tmp;
+                closest = display;
+            }
+        }
+        // Never null
+        return List.of(closest);
+    }
+
+    protected abstract Stream<Display> select(Player p, double range);
+
+}

--- a/src/main/java/goldenshadow/displayentityeditor/Utilities.java
+++ b/src/main/java/goldenshadow/displayentityeditor/Utilities.java
@@ -2,7 +2,6 @@ package goldenshadow.displayentityeditor;
 
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.Content;
 import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -14,11 +13,13 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 
+import goldenshadow.displayentityeditor.enums.LockSearchMode;
+
 import javax.annotation.Nullable;
 import java.util.List;
 
 public class Utilities {
-
+    
     /**
      * Used to easily set an items meta
      * @param item The item
@@ -32,7 +33,7 @@ public class Utilities {
         meta.setDisplayName(ChatColor.translateAlternateColorCodes('&' ,name));
         lore.replaceAll(textToTranslate -> ChatColor.translateAlternateColorCodes('&', textToTranslate));
         meta.setLore(lore);
-        meta.getPersistentDataContainer().set(new NamespacedKey(DisplayEntityEditor.getPlugin(), "tool"), PersistentDataType.STRING, data);
+        meta.getPersistentDataContainer().set(DisplayEntityEditor.toolKey, PersistentDataType.STRING, data);
 
         meta.addItemFlags(ItemFlag.values());
         meta.setUnbreakable(true);
@@ -53,7 +54,7 @@ public class Utilities {
         meta.setDisplayName(ChatColor.translateAlternateColorCodes('&' ,name));
         lore.replaceAll(textToTranslate -> ChatColor.translateAlternateColorCodes('&', textToTranslate).formatted(formatData));
         meta.setLore(lore);
-        meta.getPersistentDataContainer().set(new NamespacedKey(DisplayEntityEditor.getPlugin(), "tool"), PersistentDataType.STRING, data);
+        meta.getPersistentDataContainer().set(DisplayEntityEditor.toolKey, PersistentDataType.STRING, data);
 
         meta.addItemFlags(ItemFlag.values());
         meta.setUnbreakable(true);
@@ -67,7 +68,7 @@ public class Utilities {
      */
     public static boolean hasDataKey(ItemStack item) {
         if (item.getItemMeta() != null) {
-            return item.getItemMeta().getPersistentDataContainer().has(new NamespacedKey(DisplayEntityEditor.getPlugin(), "tool"), PersistentDataType.STRING);
+            return item.getItemMeta().getPersistentDataContainer().has(DisplayEntityEditor.toolKey, PersistentDataType.STRING);
         }
         return false;
     }
@@ -79,7 +80,7 @@ public class Utilities {
      */
     public static String getToolValue(ItemStack item) {
         if (item.getItemMeta() != null) {
-            return item.getItemMeta().getPersistentDataContainer().get(new NamespacedKey(DisplayEntityEditor.getPlugin(), "tool"), PersistentDataType.STRING);
+            return item.getItemMeta().getPersistentDataContainer().get(DisplayEntityEditor.toolKey, PersistentDataType.STRING);
         }
         return null;
     }
@@ -201,7 +202,29 @@ public class Utilities {
         else if (object instanceof ItemDisplay.ItemDisplayTransform t) {
             return DisplayEntityEditor.messageManager.getList("item_display_transform").get(t.ordinal());
         }
+        else if (object instanceof LockSearchMode m) {
+            return DisplayEntityEditor.messageManager.getList("lock_search_mode").get(m.ordinal());
+        }
+        else if (object instanceof SelectionMode m) {
+            return DisplayEntityEditor.messageManager.getList("selection_mode").get(m.index());
+        }
         else return "";
+    }
+    
+    public static SelectionMode getToolSelectMode(Player p) {
+        return SelectionMode.get(p.getPersistentDataContainer().getOrDefault(DisplayEntityEditor.toolSelectionModeKey, PersistentDataType.STRING, "nearby"));
+    }
+    
+    public static LockSearchMode getToolSearchMode(Player p) {
+        return LockSearchMode.valueOf(p.getPersistentDataContainer().getOrDefault(DisplayEntityEditor.toolSelectionSearchModeKey, PersistentDataType.STRING, "UNLOCKED"));
+    }
+    
+    public static boolean getToolSelectMultiple(Player p) {
+        return p.getPersistentDataContainer().getOrDefault(DisplayEntityEditor.toolSelectionMultipleKey,  PersistentDataType.BOOLEAN, false);
+    }
+    
+    public static float getToolSelectRange(Player p) {
+        return p.getPersistentDataContainer().getOrDefault(DisplayEntityEditor.toolSelectionRangeKey,  PersistentDataType.DOUBLE, 5d).floatValue();
     }
 
     public static float getToolPrecision(Player p) {

--- a/src/main/java/goldenshadow/displayentityeditor/enums/LockSearchMode.java
+++ b/src/main/java/goldenshadow/displayentityeditor/enums/LockSearchMode.java
@@ -1,0 +1,35 @@
+package goldenshadow.displayentityeditor.enums;
+
+import java.util.function.Predicate;
+
+import org.bukkit.entity.Display;
+
+public enum LockSearchMode {
+
+    ALL(display -> true),
+    LOCKED(display -> display.getScoreboardTags().contains("dee:locked")),
+    UNLOCKED(display -> !display.getScoreboardTags().contains("dee:locked"));
+
+    private static final LockSearchMode[] MODES = LockSearchMode.values();
+
+    private final Predicate<Display> predicate;
+
+    private LockSearchMode(final Predicate<Display> predicate) {
+        this.predicate = predicate;
+    }
+
+    public Predicate<Display> getPredicate() {
+        return predicate;
+    }
+
+    public LockSearchMode previousMode() {
+        int i = ordinal();
+        return i == 0 ? MODES[MODES.length - 1] : MODES[i - 1];
+    }
+
+    public LockSearchMode nextMode() {
+        int i = ordinal();
+        return i + 1 == MODES.length ? MODES[0] : MODES[i + 1];
+    }
+
+}

--- a/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
@@ -242,7 +242,7 @@ public class Interact implements Listener {
                 return;
             }
             case "InventoryUnlock" -> {
-                Collection<Display> displays = editingHandler.getEditingDisplays(player, LockSearchMode.UNLOCKED);
+                Collection<Display> displays = editingHandler.getEditingDisplays(player, LockSearchMode.LOCKED);
 
                 if (displays == null) {
                     player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("unlock_fail")));

--- a/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
@@ -175,6 +175,10 @@ public class Interact implements Listener {
                                     p.getInventory().setItem(i, DisplayEntityEditor.inventoryFactory.getInventoryItems().scaleY(p));
                             case "InventorySZ" ->
                                     p.getInventory().setItem(i, DisplayEntityEditor.inventoryFactory.getInventoryItems().scaleZ(p));
+                            case "InventoryToolPrecision" -> 
+                                    p.getInventory().setItem(i, DisplayEntityEditor.inventoryFactory.getInventoryItems().toolPrecision(p));
+                            case "InventoryToolSelectionRange" ->
+                                    p.getInventory().setItem(i, DisplayEntityEditor.inventoryFactory.getInventoryItems().toolSelectionRange(p));
                             case "InventoryToolSelectionMode" ->
                                     p.getInventory().setItem(i, DisplayEntityEditor.inventoryFactory.getInventoryItems().toolSelectionMode(p));
                             case "InventoryGroupSelect" ->

--- a/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/Interact.java
@@ -20,6 +20,7 @@ import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.function.Predicate;
 
 public class Interact implements Listener {
 
@@ -654,10 +655,11 @@ public class Interact implements Listener {
             case "InventoryGroupSelect" -> {
                 if (!player.isSneaking()) {
                     Collection<Display> group = new HashSet<>();
-                    double distance = Utilities.getToolPrecision(player);
+                    double distance = Utilities.getToolSelectRange(player);
+                    Predicate<Display> predicate = Utilities.getToolSearchMode(player).getPredicate();
                     for (Entity e : player.getNearbyEntities(distance,distance,distance)) {
                         if (e instanceof Display d) {
-                            if (!d.getScoreboardTags().contains("dee:locked")) {
+                            if (predicate.test(d)) {
                                 group.add(d);
                                 highlightEntity(d);
                             }

--- a/src/main/java/goldenshadow/displayentityeditor/events/OffhandSwap.java
+++ b/src/main/java/goldenshadow/displayentityeditor/events/OffhandSwap.java
@@ -32,14 +32,37 @@ public class OffhandSwap implements Listener {
 
         ItemStack item = player.getInventory().getItemInMainHand();
         String toolValue = Utilities.getToolValue(item);
-        Collection<Display> displays = editingHandler.getEditingDisplays(player, true);
-
-        if (displays == null) {
-            player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("generic_fail")));
-            return;
-        }
 
         if (toolValue == null) {
+            return;
+        }
+        
+        switch(toolValue) {
+        case "InventoryToolSelectionMode" -> {
+            Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("value_reset"));
+            player.getPersistentDataContainer().remove(DisplayEntityEditor.toolSelectionModeKey);
+            return;
+        }
+        case "InventoryToolSelectionRange" -> {
+            Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("value_reset"));
+            player.getPersistentDataContainer().remove(DisplayEntityEditor.toolSelectionRangeKey);
+            return;
+        }
+        case "InventoryToolSelectionSearchMode" -> {
+            Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("value_reset"));
+            player.getPersistentDataContainer().remove(DisplayEntityEditor.toolSelectionSearchModeKey);
+            return;
+        }
+        case "InventoryToolSelectionMultiple" -> {
+            Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("value_reset"));
+            player.getPersistentDataContainer().remove(DisplayEntityEditor.toolSelectionMultipleKey);
+            return;
+        }
+        }
+        
+        Collection<Display> displays = editingHandler.getEditingDisplays(player);
+        if (displays == null) {
+            player.sendMessage(Utilities.getErrorMessageFormat(DisplayEntityEditor.messageManager.getString("generic_fail")));
             return;
         }
         Utilities.sendActionbarMessage(player, DisplayEntityEditor.messageManager.getString("value_reset"));

--- a/src/main/java/goldenshadow/displayentityeditor/inventories/InventoryFactory.java
+++ b/src/main/java/goldenshadow/displayentityeditor/inventories/InventoryFactory.java
@@ -163,8 +163,8 @@ public class InventoryFactory {
         array[3] = inventoryItems.toolSearchMode();
         array[4] = inventoryItems.toolSelectionMode(p);
         array[6] = inventoryItems.toolSelectionMultiple();
-        array[5] = inventoryItems.toolSelectionRange();
-        array[7] = inventoryItems.toolPrecision();
+        array[5] = inventoryItems.toolSelectionRange(p);
+        array[7] = inventoryItems.toolPrecision(p);
 
         array[27] = inventoryItems.spawnItemDisplay();
         array[28] = inventoryItems.spawnBlockDisplay();

--- a/src/main/java/goldenshadow/displayentityeditor/inventories/InventoryFactory.java
+++ b/src/main/java/goldenshadow/displayentityeditor/inventories/InventoryFactory.java
@@ -158,20 +158,22 @@ public class InventoryFactory {
         ItemStack[] array = new ItemStack[36];
 
         array[0] = inventoryItems.gui();
-        array[1] = inventoryItems.rotateYaw(p);
-        array[2] = inventoryItems.rotatePitch(p);
-        array[3] = inventoryItems.moveX(p);
-        array[4] = inventoryItems.moveY(p);
-        array[5] = inventoryItems.moveZ(p);
-        array[6] = inventoryItems.toolPrecision();
+        array[1] = inventoryItems.cloneTool();
+        array[2] = inventoryItems.groupSelectTool(p);
+        array[3] = inventoryItems.toolSearchMode();
+        array[4] = inventoryItems.toolSelectionMode(p);
+        array[6] = inventoryItems.toolSelectionMultiple();
+        array[5] = inventoryItems.toolSelectionRange();
+        array[7] = inventoryItems.toolPrecision();
 
         array[27] = inventoryItems.spawnItemDisplay();
         array[28] = inventoryItems.spawnBlockDisplay();
         array[29] = inventoryItems.spawnTextDisplay();
-        array[30] = inventoryItems.centerPivot();
-        array[31] = inventoryItems.highlightTarget();
-        array[32] = inventoryItems.unlock();
-        array[33] = inventoryItems.centerOnBlock();
+        array[30] = inventoryItems.moveX(p);
+        array[31] = inventoryItems.moveY(p);
+        array[32] = inventoryItems.moveZ(p);
+        array[33] = inventoryItems.rotateYaw(p);
+        array[34] = inventoryItems.rotatePitch(p);
 
         array[18] = inventoryItems.translationX(p);
         array[19] = inventoryItems.translationY(p);
@@ -179,7 +181,8 @@ public class InventoryFactory {
         array[21] = inventoryItems.scaleX(p);
         array[22] = inventoryItems.scaleY(p);
         array[23] = inventoryItems.scaleZ(p);
-        array[24] = inventoryItems.cloneTool();
+        array[24] = inventoryItems.highlightTarget();
+        array[25] = inventoryItems.unlock();
 
         array[9] = inventoryItems.leftRotationX(p);
         array[10] = inventoryItems.leftRotationY(p);
@@ -187,7 +190,8 @@ public class InventoryFactory {
         array[12] = inventoryItems.rightRotationX(p);
         array[13] = inventoryItems.rightRotationY(p);
         array[14] = inventoryItems.rightRotationZ(p);
-        array[15] = inventoryItems.groupSelectTool(p);
+        array[15] = inventoryItems.centerPivot();
+        array[16] = inventoryItems.centerOnBlock();
 
         return array;
     }

--- a/src/main/java/goldenshadow/displayentityeditor/items/InventoryItems.java
+++ b/src/main/java/goldenshadow/displayentityeditor/items/InventoryItems.java
@@ -377,7 +377,7 @@ public class InventoryItems {
      * @return The item
      */
     public ItemStack toolSelectionMode(Player p) {
-        ItemStack itemStack = new ItemStack(Material.COMPASS);
+        ItemStack itemStack = new ItemStack(Material.RECOVERY_COMPASS);
         SelectionMode mode = Utilities.getToolSelectMode(p);
         ArrayList<String> lore = new ArrayList<>();
         lore.addAll(DisplayEntityEditor.messageManager.getList("tool_selection_mode_lore_start"));

--- a/src/main/java/goldenshadow/displayentityeditor/items/InventoryItems.java
+++ b/src/main/java/goldenshadow/displayentityeditor/items/InventoryItems.java
@@ -361,11 +361,13 @@ public class InventoryItems {
      * Creates the tool precision item
      * @return The item
      */
-    public ItemStack toolPrecision() {
+    public ItemStack toolPrecision(Player p) {
+        float precision = Utilities.getToolPrecision(p);
         ItemStack itemStack = new ItemStack(Material.COMPARATOR);
         Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("tool_precision_name"),
                 DisplayEntityEditor.messageManager.getList("tool_precision_lore"),
-                "InventoryToolPrecision"
+                "InventoryToolPrecision",
+                Utilities.reduceFloatLength(Double.toString(precision < 1 ? 0.1f : 1f))
         );
         return itemStack;
     }
@@ -394,11 +396,13 @@ public class InventoryItems {
      * Creates the tool selection range item
      * @return The item
      */
-    public ItemStack toolSelectionRange() {
+    public ItemStack toolSelectionRange(Player p) {
+        float range = Utilities.getToolSelectRange(p);
         ItemStack itemStack = new ItemStack(Material.SPECTRAL_ARROW);
         Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("tool_selection_range_name"),
                 DisplayEntityEditor.messageManager.getList("tool_selection_range_lore"),
-                "InventoryToolSelectionRange"
+                "InventoryToolSelectionRange",
+                Utilities.reduceFloatLength(Double.toString(range < 2 ? 0.25f : 1f))
         );
         return itemStack;
     }

--- a/src/main/java/goldenshadow/displayentityeditor/items/InventoryItems.java
+++ b/src/main/java/goldenshadow/displayentityeditor/items/InventoryItems.java
@@ -1,7 +1,11 @@
 package goldenshadow.displayentityeditor.items;
 
 import goldenshadow.displayentityeditor.DisplayEntityEditor;
+import goldenshadow.displayentityeditor.SelectionMode;
 import goldenshadow.displayentityeditor.Utilities;
+
+import java.util.ArrayList;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -367,6 +371,65 @@ public class InventoryItems {
     }
 
     /**
+     * Creates the tool selection mode item
+     * @return The item
+     */
+    public ItemStack toolSelectionMode(Player p) {
+        ItemStack itemStack = new ItemStack(Material.COMPASS);
+        SelectionMode mode = Utilities.getToolSelectMode(p);
+        ArrayList<String> lore = new ArrayList<>();
+        lore.addAll(DisplayEntityEditor.messageManager.getList("tool_selection_mode_lore_start"));
+        lore.addAll(DisplayEntityEditor.messageManager.getList("tool_selection_mode_description_" + mode.id()));
+        lore.addAll(DisplayEntityEditor.messageManager.getList("tool_selection_mode_lore_end"));
+        Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("tool_selection_mode_name"),
+                lore,
+                "InventoryToolSelectionMode",
+                Utilities.getObjectNameMessage(mode),
+                Utilities.reduceFloatLength(Double.toString(Utilities.getToolSelectRange(p)))
+        );
+        return itemStack;
+    }
+
+    /**
+     * Creates the tool selection range item
+     * @return The item
+     */
+    public ItemStack toolSelectionRange() {
+        ItemStack itemStack = new ItemStack(Material.SPECTRAL_ARROW);
+        Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("tool_selection_range_name"),
+                DisplayEntityEditor.messageManager.getList("tool_selection_range_lore"),
+                "InventoryToolSelectionRange"
+        );
+        return itemStack;
+    }
+
+    /**
+     * Creates the tool selection search mode item
+     * @return The item
+     */
+    public ItemStack toolSearchMode() {
+        ItemStack itemStack = new ItemStack(Material.CLOCK);
+        Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("tool_selection_search_mode_name"),
+                DisplayEntityEditor.messageManager.getList("tool_selection_search_mode_lore"),
+                "InventoryToolSelectionSearchMode"
+        );
+        return itemStack;
+    }
+
+    /**
+     * Creates the tool selection multiple item
+     * @return The item
+     */
+    public ItemStack toolSelectionMultiple() {
+        ItemStack itemStack = new ItemStack(Material.CHEST);
+        Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("tool_selection_multiple_name"),
+                DisplayEntityEditor.messageManager.getList("tool_selection_multiple_lore"),
+                "InventoryToolSelectionMultiple"
+        );
+        return itemStack;
+    }
+
+    /**
      * Creates the clone item
      * @return The item
      */
@@ -388,7 +451,7 @@ public class InventoryItems {
         Utilities.setMeta(itemStack, DisplayEntityEditor.messageManager.getString("group_select_name"),
                 DisplayEntityEditor.messageManager.getList("group_select_lore"),
                 "InventoryGroupSelect",
-                Utilities.reduceFloatLength(Double.toString(Utilities.getToolPrecision(p)))
+                Utilities.reduceFloatLength(Double.toString(Utilities.getToolSelectRange(p)))
         );
         return itemStack;
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -67,6 +67,17 @@ clone_tool_name: "&eClone Display Entity"
 clone_tool_lore: ["&7Click to duplicate the nearest", "&7display entity", " ", "&e&lRIGHT-CLICK&r&e to clone"]
 group_select_name: "&eGroup Select"
 group_select_lore: ["&7Click to add a display entities within", "&7the current range to a group, where", "&7all entities will be edited simultaneously", " ", "&e&lRIGHT-CLICK&r&e to select all within %s blocks", "&e&lSHIFT RIGHT-CLICK&r&e to clear group"]
+tool_selection_range_name: "&eChange Selection Range"
+tool_selection_range_lore: ["&7Click to change your selection range.", " ", "&e&lRIGHT_CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s", "&e&lOFFHAND &r&eto reset value"]
+tool_selection_search_mode_name: "&eChange Search Mode"
+tool_selection_search_mode_lore: ["&7Click to change your lock search mode.", " ", "&e&lRIGHT_CLICK&r&e to cycle forwards", "&e&lSHIFT RIGHT-CLICK&r&e to cycle backwards", "&e&lOFFHAND &r&eto reset value"]
+tool_selection_multiple_name: "&eChange Single/Multi Selection"
+tool_selection_multiple_lore: ["&7Click to change if you want to", "&7select one of multiple each operation.", " ", "&e&lRIGHT-CLICK&r&e to toggle", "&e&lOFFHAND &r&eto reset value"]
+tool_selection_mode_name: "&eChange Selection Mode"
+tool_selection_mode_lore_header: ["&7Click to change your selection mode.", " ", "&7Your current Selection Mode: &e%s", " "]
+tool_selection_mode_lore_end: [" ", "&e&lRIGHT_CLICK&r&e to cycle forwards", "&e&lSHIFT RIGHT-CLICK&r&e to cycle backwards", "&e&lOFFHAND &r&eto reset value"]
+tool_selection_mode_description_nearby: ["&7This mode will select the closest", "&7entity or entities within &e%2$s blocks", "&7depending on if you are in the", "&7single or multi selection mode."]
+tool_selection_mode_description_raycast: ["&7This mode will select the entity", "&7you are looking at."]
 
 # GUI Items
 name_name: "&eSet Name"
@@ -146,13 +157,17 @@ text_append_hint: "Please enter the text in chat that should be appended! You ca
 block_invalid_hint: "Invalid block! The item must be a block item!"
 
 #Tool feedback
-generic_fail: "There is no unlocked display entity within 5 blocks!"
+generic_fail: "Couldn't find a display entity that matches your selection settings!"
 item_display_spawned: "Spawned new item display entity!"
 block_display_spawned: "Spawned new block display entity!"
 text_display_spawned: "Spawned new text display entity!"
 unlock_fail: "There is no locked display entity within 5 blocks!"
 unlock_success: "Display entity unlocked!"
 tool_precision: "Tool Precision: %s"
+tool_range: "Tool Range: %s"
+tool_selection_changed: "Selection Mode: %s"
+tool_search_changed: "Lock Search Mode: %s"
+tool_multiple_changed: "Select Multiple: %s"
 gui_open_fail: "Someone else is editing this entity at the moment!"
 gui_only_single_displays: "This GUI is only for modifying single display entities!"
 yaw: "Yaw: %s"
@@ -222,6 +237,8 @@ text_alignment: ["CENTER", "LEFT", "RIGHT"]
 billboard: ["CENTER", "FIXED", "HORIZONTAL", "VERTICAL"]
 rgb: "RGB: %d, %d, %d"
 item_display_transform: ["FIRSTPERSON_LEFTHAND", "FIRSTPERSON_RIGHTHAND", "FIXED", "GROUND", "GUI", "HEAD", "NONE", "THIRDPERSON_LEFTHAND", "THIRDPERSON_RIGHTHAND"]
+selection_mode: ["Nearby", "Raycast"]
+lock_search_mode: ["All", "Locked only", "Unlocked only"]
 
 #GUI names
 block_display_gui_name: "&lBlock Display GUI"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -62,13 +62,13 @@ scale_lore: ["&7Click to change the scale of the", "&7nearest unlocked display e
 center_on_block_name: "&eCenter On Block"
 center_on_block_lore: ["&7Click to position the nearest display entity", "&7so that it is centered on the block.", " ", "&e&lRIGHT-CLICK&r&e to center xyz", "&e&lSHIFT RIGHT-CLICK&r&e to center xz"]
 tool_precision_name: "&eChange Tool Precision"
-tool_precision_lore: ["&7Click to change the multiplier for", "&7your tools precision.", " ", "&e&lRIGHT-CLICK&r&e to increase by 1", "&e&lSHIFT RIGHT-CLICK&r&e to decrease by 1"]
+tool_precision_lore: ["&7Click to change the multiplier for", "&7your tools precision.", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s"]
 clone_tool_name: "&eClone Display Entity"
 clone_tool_lore: ["&7Click to duplicate the nearest", "&7display entity", " ", "&e&lRIGHT-CLICK&r&e to clone"]
 group_select_name: "&eGroup Select"
 group_select_lore: ["&7Click to add a display entities within", "&7the current range to a group, where", "&7all entities will be edited simultaneously", " ", "&e&lRIGHT-CLICK&r&e to select all within %s blocks", "&e&lSHIFT RIGHT-CLICK&r&e to clear group"]
 tool_selection_range_name: "&eChange Selection Range"
-tool_selection_range_lore: ["&7Click to change your selection range.", " ", "&e&lRIGHT_CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s", "&e&lOFFHAND &r&eto reset value"]
+tool_selection_range_lore: ["&7Click to change your selection range.", " ", "&e&lRIGHT-CLICK&r&e to change by +%s", "&e&lSHIFT RIGHT-CLICK&r&e to change by -%s", "&e&lOFFHAND &r&eto reset value"]
 tool_selection_search_mode_name: "&eChange Search Mode"
 tool_selection_search_mode_lore: ["&7Click to change your lock search mode.", " ", "&e&lRIGHT_CLICK&r&e to cycle forwards", "&e&lSHIFT RIGHT-CLICK&r&e to cycle backwards", "&e&lOFFHAND &r&eto reset value"]
 tool_selection_multiple_name: "&eChange Single/Multi Selection"


### PR DESCRIPTION
I added a raycast selection mode as it annoyed me that each operation would just chose the closest entity.
I also added the ability to switch between selection modes as well as choosing if locked entities should be effected or not.
Additionally I made it so the precision tools' description would update accordingly.

For this to work I had to resort the inventory a little, I tried to do as less changes as possible and to stay in the pattern.

I opened this PR as I think people would appreciate a raycast method and even if it isn't being merged I got what I wanted, just sharing it to everyone else :)